### PR TITLE
CS-36: hide close button until tap

### DIFF
--- a/src/android/ConversationActivity.java
+++ b/src/android/ConversationActivity.java
@@ -459,6 +459,7 @@ public class ConversationActivity extends AppCompatActivity
     }
     
     private void setNavVisibility(boolean visible) {
+        
         int newVis = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
@@ -482,6 +483,10 @@ public class ConversationActivity extends AppCompatActivity
 
         // Set the new desired visibility.
         view.setSystemUiVisibility(newVis);
+        
+        disconnectActionFab.animate()
+            .alpha(visible ? 1.0f : 0.0f)
+            .setDuration(400);
     }
 
 }


### PR DESCRIPTION
This kills two birds with one stone: CS-24 requests that the close button hides until you tap.  The issue is the first tap is swallowed by the video view and then you have to tap again (CS-36).  This is kind of cheating, but it feels like a better UI to me.