### PR TITLE
CS:24 - hide button on tap, iOS fix

### DIFF
--- a/src/ios/TwilioVideoViewController.h
+++ b/src/ios/TwilioVideoViewController.h
@@ -11,6 +11,8 @@
 @end
 
 @interface TwilioVideoViewController : UIViewController
+extern const double ANIMATION_DURATION;
+extern const double TIMER_INTERVAL;
 @property (assign) id <TwilioVideoViewControllerDelegate> delegate;
 @property (nonatomic, strong) NSString *accessToken;
 @property (nonatomic, strong) NSString *remoteParticipantName;

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -42,7 +42,8 @@
 @property (nonatomic, weak) IBOutlet UIButton *disconnectButton;
 @property (nonatomic, weak) IBOutlet UILabel *messageLabel;
 
-@property (nonatomic, assign) BOOL tappedVideoView;
+@property (nonatomic, assign) NSTimer *timer;
+@property (nonatomic, assign) BOOL disconnectButtonVisible;
 
 @end
 
@@ -58,8 +59,10 @@
     
     // Configure access token manually for testing, if desired! Create one manually in the console
     //  self.accessToken = @"TWILIO_ACCESS_TOKEN";
-    
-    self.tappedVideoView = NO;
+
+//    self.timer = [NSTimer scheduledTimerWithTimeInterval:6 target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
+    self.disconnectButtonVisible = YES;
+    [self startTimer];
     
 }
 
@@ -73,30 +76,41 @@
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    [self.disconnectButton.layer removeAllAnimations];
-    if (!self.tappedVideoView) {
-        [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
-            self.disconnectButton.userInteractionEnabled = YES;
-            self.disconnectButton.layer.opacity = 0.1f;
-        } completion: nil];
+    if(!self.disconnectButtonVisible) {
+        self.disconnectButtonVisible = !self.disconnectButtonVisible;
+        [self showDisconnectButton];
+        [self startTimer];
     } else {
-        [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
-            self.disconnectButton.userInteractionEnabled = YES;
-            self.disconnectButton.layer.opacity = 1.0f;
-        } completion: ^(BOOL finished) {
-            if (finished) {
-                [UIView animateWithDuration:0.4 delay:6 options:UIViewAnimationOptionAllowUserInteraction animations:^{
-                    self.disconnectButton.userInteractionEnabled = YES;
-                    self.disconnectButton.layer.opacity = 0.1f;
-                } completion: ^(BOOL finished) {
-                    if (finished) {
-                        self.tappedVideoView = !self.tappedVideoView;
-                    }
-                }];
-            }
-        }];
+        [self resetTimer];
     }
-    self.tappedVideoView = !self.tappedVideoView;
+}
+
+-(void)hideDisconnectButton {
+    [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+        self.disconnectButton.userInteractionEnabled = YES;
+        self.disconnectButton.layer.opacity = 0.01f;
+    } completion: ^(BOOL finished) {
+        if(finished) {
+            self.disconnectButtonVisible = !self.disconnectButtonVisible;
+        }
+    }];
+}
+
+-(void)showDisconnectButton {
+    [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+        self.disconnectButton.userInteractionEnabled = YES;
+        self.disconnectButton.layer.opacity = 1.0f;
+    } completion: nil];
+}
+
+-(void)startTimer {
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:6 target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
+}
+
+-(void)resetTimer {
+    [self.timer invalidate];
+    self.timer = nil;
+    [self startTimer];
 }
 
 #pragma mark - Public

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -60,7 +60,6 @@
     // Configure access token manually for testing, if desired! Create one manually in the console
     //  self.accessToken = @"TWILIO_ACCESS_TOKEN";
 
-//    self.timer = [NSTimer scheduledTimerWithTimeInterval:6 target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
     self.disconnectButtonVisible = YES;
     [self startTimer];
     

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -43,7 +43,6 @@
 @property (nonatomic, weak) IBOutlet UILabel *messageLabel;
 
 @property (nonatomic, assign) NSTimer *timer;
-@property (nonatomic, assign) BOOL disconnectButtonVisible;
 
 @end
 
@@ -60,7 +59,6 @@
     // Configure access token manually for testing, if desired! Create one manually in the console
     //  self.accessToken = @"TWILIO_ACCESS_TOKEN";
 
-    self.disconnectButtonVisible = YES;
     [self startTimer];
     
 }
@@ -75,8 +73,8 @@
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    if(!self.disconnectButtonVisible) {
-        self.disconnectButtonVisible = !self.disconnectButtonVisible;
+    if(self.disconnectButton.hidden) {
+        self.disconnectButton.hidden = !self.disconnectButton.hidden;
         [self showDisconnectButton];
         [self startTimer];
     } else {
@@ -89,7 +87,7 @@
         self.disconnectButton.layer.opacity = 0.0f;
     } completion: ^(BOOL finished) {
         if(finished) {
-            self.disconnectButtonVisible = !self.disconnectButtonVisible;
+            self.disconnectButton.hidden = !self.disconnectButton.hidden;
         }
     }];
 }

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -83,7 +83,7 @@
         } completion: nil];
     } else {
         [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
-            self.disconnectButton.transform = CGAffineTransformMakeScale(0.95, 0.95);
+            self.disconnectButton.transform = CGAffineTransformMakeScale(0.99, 0.99);
         } completion: ^(BOOL finished) {
             [UIView animateWithDuration:0 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
                 self.disconnectButton.transform = CGAffineTransformMakeScale(1, 1);

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -88,7 +88,7 @@
 -(void)hideDisconnectButton {
     [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
         self.disconnectButton.userInteractionEnabled = YES;
-        self.disconnectButton.layer.opacity = 0.01f;
+        self.disconnectButton.layer.opacity = 0.0f;
     } completion: ^(BOOL finished) {
         if(finished) {
             self.disconnectButtonVisible = !self.disconnectButtonVisible;

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -103,7 +103,7 @@
 }
 
 -(void)startTimer {
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:6 target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:4 target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
 }
 
 -(void)resetTimer {

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -86,7 +86,6 @@
 
 -(void)hideDisconnectButton {
     [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
-        self.disconnectButton.userInteractionEnabled = YES;
         self.disconnectButton.layer.opacity = 0.0f;
     } completion: ^(BOOL finished) {
         if(finished) {
@@ -97,7 +96,6 @@
 
 -(void)showDisconnectButton {
     [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
-        self.disconnectButton.userInteractionEnabled = YES;
         self.disconnectButton.layer.opacity = 1.0f;
     } completion: nil];
 }

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -60,8 +60,6 @@
     //  self.accessToken = @"TWILIO_ACCESS_TOKEN";
     
     self.tappedVideoView = NO;
-    UITapGestureRecognizer *singleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTapGesture:)];
-    [self.view addGestureRecognizer:singleTapGestureRecognizer];
     
 }
 
@@ -74,26 +72,30 @@
                                 forKey:@"orientation"];
 }
 
-#pragma mark - Public
-
--(void)handleSingleTapGesture:(UITapGestureRecognizer *)tapGestureRecognizer{
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self.disconnectButton.layer removeAllAnimations];
     if (!self.tappedVideoView) {
-        [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
-            self.disconnectButton.transform = CGAffineTransformMakeScale(0.001, 0.001);
+        self.tappedVideoView = !self.tappedVideoView;
+        [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+            self.disconnectButton.userInteractionEnabled = YES;
+            self.disconnectButton.layer.opacity = 0.1f;
         } completion: nil];
     } else {
-        [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
-            self.disconnectButton.transform = CGAffineTransformMakeScale(0.99, 0.99);
+        self.tappedVideoView = !self.tappedVideoView;
+        [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+            self.disconnectButton.userInteractionEnabled = YES;
+            self.disconnectButton.layer.opacity = 1.0f;
         } completion: ^(BOOL finished) {
-            [UIView animateWithDuration:0 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
-                self.disconnectButton.transform = CGAffineTransformMakeScale(1, 1);
+            [UIView animateWithDuration:0.4 delay:6 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+                self.disconnectButton.userInteractionEnabled = YES;
+                self.disconnectButton.layer.opacity = 0.1f;
             } completion: nil];
         }];
     }
-    self.tappedVideoView = !self.tappedVideoView;
-    
 }
 
+#pragma mark - Public
+    
 - (void)connectToRoom:(NSString*)room {
     [self showRoomUI:YES];
     

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -77,13 +77,20 @@
 #pragma mark - Public
 
 -(void)handleSingleTapGesture:(UITapGestureRecognizer *)tapGestureRecognizer{
-    if (self.tappedVideoView == NO) {
-        self.disconnectButton.hidden = YES;
-        self.tappedVideoView = YES;
+    if (!self.tappedVideoView) {
+        [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
+            self.disconnectButton.transform = CGAffineTransformMakeScale(0.001, 0.001);
+        } completion: nil];
     } else {
-        self.disconnectButton.hidden = NO;
-        self.tappedVideoView = NO;
+        [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
+            self.disconnectButton.transform = CGAffineTransformMakeScale(0.95, 0.95);
+        } completion: ^(BOOL finished) {
+            [UIView animateWithDuration:0 delay:0 options:UIViewAnimationOptionCurveLinear  animations:^{
+                self.disconnectButton.transform = CGAffineTransformMakeScale(1, 1);
+            } completion: nil];
+        }];
     }
+    self.tappedVideoView = !self.tappedVideoView;
     
 }
 

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -42,6 +42,8 @@
 @property (nonatomic, weak) IBOutlet UIButton *disconnectButton;
 @property (nonatomic, weak) IBOutlet UILabel *messageLabel;
 
+@property (nonatomic, assign) BOOL tappedVideoView;
+
 @end
 
 @implementation TwilioVideoViewController
@@ -56,6 +58,11 @@
     
     // Configure access token manually for testing, if desired! Create one manually in the console
     //  self.accessToken = @"TWILIO_ACCESS_TOKEN";
+    
+    self.tappedVideoView = NO;
+    UITapGestureRecognizer *singleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTapGesture:)];
+    [self.view addGestureRecognizer:singleTapGestureRecognizer];
+    
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -68,6 +75,17 @@
 }
 
 #pragma mark - Public
+
+-(void)handleSingleTapGesture:(UITapGestureRecognizer *)tapGestureRecognizer{
+    if (self.tappedVideoView == NO) {
+        self.disconnectButton.hidden = YES;
+        self.tappedVideoView = YES;
+    } else {
+        self.disconnectButton.hidden = NO;
+        self.tappedVideoView = NO;
+    }
+    
+}
 
 - (void)connectToRoom:(NSString*)room {
     [self showRoomUI:YES];

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -47,6 +47,8 @@
 @end
 
 @implementation TwilioVideoViewController
+const double ANIMATION_DURATION = 0.4;
+const double TIMER_INTERVAL = 4;
 @synthesize delegate;
 
 #pragma mark - UIViewController
@@ -83,7 +85,7 @@
 }
 
 -(void)hideDisconnectButton {
-    [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+    [UIView animateWithDuration:ANIMATION_DURATION delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
         self.disconnectButton.layer.opacity = 0.0f;
     } completion: ^(BOOL finished) {
         if(finished) {
@@ -93,13 +95,13 @@
 }
 
 -(void)showDisconnectButton {
-    [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+    [UIView animateWithDuration:ANIMATION_DURATION delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
         self.disconnectButton.layer.opacity = 1.0f;
     } completion: nil];
 }
 
 -(void)startTimer {
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:4 target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:TIMER_INTERVAL target:self selector:@selector(hideDisconnectButton) userInfo:nil repeats:NO];
 }
 
 -(void)resetTimer {

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -75,23 +75,28 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [self.disconnectButton.layer removeAllAnimations];
     if (!self.tappedVideoView) {
-        self.tappedVideoView = !self.tappedVideoView;
         [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
             self.disconnectButton.userInteractionEnabled = YES;
             self.disconnectButton.layer.opacity = 0.1f;
         } completion: nil];
     } else {
-        self.tappedVideoView = !self.tappedVideoView;
         [UIView animateWithDuration:0.4 delay:0 options:UIViewAnimationOptionAllowUserInteraction animations:^{
             self.disconnectButton.userInteractionEnabled = YES;
             self.disconnectButton.layer.opacity = 1.0f;
         } completion: ^(BOOL finished) {
-            [UIView animateWithDuration:0.4 delay:6 options:UIViewAnimationOptionAllowUserInteraction animations:^{
-                self.disconnectButton.userInteractionEnabled = YES;
-                self.disconnectButton.layer.opacity = 0.1f;
-            } completion: nil];
+            if (finished) {
+                [UIView animateWithDuration:0.4 delay:6 options:UIViewAnimationOptionAllowUserInteraction animations:^{
+                    self.disconnectButton.userInteractionEnabled = YES;
+                    self.disconnectButton.layer.opacity = 0.1f;
+                } completion: ^(BOOL finished) {
+                    if (finished) {
+                        self.tappedVideoView = !self.tappedVideoView;
+                    }
+                }];
+            }
         }];
     }
+    self.tappedVideoView = !self.tappedVideoView;
 }
 
 #pragma mark - Public


### PR DESCRIPTION
This PR updates the cordova plugin for iOS version. When user taps on the screen, the disconnect will hide and it will reappear when the user taps again on the screen. 

Related Issue: [CS-24](https://capehq.atlassian.net/browse/CS-24)