### PR TITLE
CS-56: plugin result iOS fix

### DIFF
--- a/src/ios/TwilioVideoPlugin.m
+++ b/src/ios/TwilioVideoPlugin.m
@@ -40,6 +40,7 @@
 - (void) dismissTwilioVideoController {
     [self.viewController dismissViewControllerAnimated: YES completion: ^ {
         if (self.callbackId != nil) {
+            NSString * cbid = self.callbackId;
             self.callbackId = nil;
             CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK  messageAsString:@"closed"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:cbid];

--- a/src/ios/TwilioVideoPlugin.m
+++ b/src/ios/TwilioVideoPlugin.m
@@ -29,7 +29,7 @@
         
         [self.viewController presentViewController:vc animated:YES completion:^{
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"opened"];
-            [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+            [pluginResult setKeepCallbackAsBool:YES];
             [vc connectToRoom:room];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
         }];
@@ -40,7 +40,6 @@
 - (void) dismissTwilioVideoController {
     [self.viewController dismissViewControllerAnimated: YES completion: ^ {
         if (self.callbackId != nil) {
-            NSString * cbid = [self.callbackId copy];
             self.callbackId = nil;
             CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK  messageAsString:@"closed"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:cbid];

--- a/src/ios/TwilioVideoViewController.h
+++ b/src/ios/TwilioVideoViewController.h
@@ -6,8 +6,12 @@
 
 @import UIKit;
 
-@interface TwilioVideoViewController : UIViewController
+@protocol TwilioVideoViewControllerDelegate <NSObject>
+-(void)dismiss;
+@end
 
+@interface TwilioVideoViewController : UIViewController
+@property (assign) id <TwilioVideoViewControllerDelegate> delegate;
 @property (nonatomic, strong) NSString *accessToken;
 @property (nonatomic, strong) NSString *remoteParticipantName;
 

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -45,6 +45,7 @@
 @end
 
 @implementation TwilioVideoViewController
+@synthesize delegate;
 
 #pragma mark - UIViewController
 
@@ -81,7 +82,7 @@
 
 - (IBAction)disconnectButtonPressed:(id)sender {
     [self.room disconnect];
-    [self dismissViewControllerAnimated:true completion:nil];
+    [self.delegate dismiss];
 }
 
 #pragma mark - Private
@@ -195,7 +196,7 @@
     self.room = nil;
     
     [self showRoomUI:NO];
-    [self dismissViewControllerAnimated:true completion:nil];
+    [self.delegate dismiss];
 }
 
 - (void)room:(TVIRoom *)room didFailToConnectWithError:(nonnull NSError *)error{
@@ -204,7 +205,7 @@
     self.room = nil;
     
     [self showRoomUI:NO];
-    [self dismissViewControllerAnimated:true completion:nil];
+    [self.delegate dismiss];
 }
 
 - (void)room:(TVIRoom *)room participantDidConnect:(TVIParticipant *)participant {
@@ -217,7 +218,7 @@
     if (self.viewedParticipant == participant) {
         [self logMessage:@"Participant disconnected"];
         [self cleanupRemoteParticipant];
-        [self dismissViewControllerAnimated:true completion:nil];
+        [self.delegate dismiss];
     }
 }
 
@@ -241,7 +242,7 @@
         [videoTrack removeRenderer:self.remoteView];
         [self.remoteView removeFromSuperview];
         [self cleanupRemoteParticipant];
-        [self dismissViewControllerAnimated:true completion:nil];
+        [self.delegate dismiss];
 		// TODO: This will kick us out....some ideas:
 		//  1. Search for another participant with a video track (requires saving all participants or tracking in addedVideoTrack)
     }


### PR DESCRIPTION
In this PR, the callback property `setKeepCallback` is set to true so that the same callback id can be used to communicate back to the Ionic app when the TwilioVideo is closed by the user. 

`TwilioVideoViewControllerDelegate`'s method `dismiss` was added to call the method `dismissTwilioVideoController` in file `TwilioVideoPlugin.m` instead of calling `dismissViewControllerAnimated` in `TwilioVideoViewController.m`